### PR TITLE
[stable/velero] fix velero installation on azure landscape - add missing envs

### DIFF
--- a/stable/velero/Chart.yaml
+++ b/stable/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.1.0
 description: A Helm chart for velero
 name: velero
-version: 2.3.0
+version: 2.3.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/velero/templates/deployment.yaml
+++ b/stable/velero/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
           volumeMounts:
             - name: plugins
               mountPath: /plugins
-        {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
+        {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp") (eq $provider "azure")) }}
             - name: cloud-credentials
               mountPath: /credentials
             - name: scratch
@@ -90,11 +90,13 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-          {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
+          {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp") (eq $provider "azure")) }}
             {{- if eq $provider "aws" }}
             - name: AWS_SHARED_CREDENTIALS_FILE
-            {{- else }}
+            {{- else if eq $provider "gcp" }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
+            {{- else }}
+            - name: AZURE_CREDENTIALS_FILE
             {{- end }}
               value: /credentials/cloud
           {{- end }}
@@ -109,7 +111,7 @@ spec:
         {{- toYaml .Values.initContainers | nindent 8 }}
 {{- end }}
       volumes:
-        {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
+        {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp") (eq $provider "azure")) }}
         - name: cloud-credentials
           secret:
             secretName: {{ include "velero.secretName" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Installing velero on K8S using helm does not provide all the required secret and env values which causes pod failures due to missing env values.
time="2019-10-30T17:34:51Z" level=info msg="Checking that all backup storage locations are valid" logSource="pkg/cmd/server/server.go:412"
An error occurred: some backup storage locations are invalid: error getting backup store for location "default": rpc error: code = Unknown desc = unable to get all required environment variables: the following keys do not have values: AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID

#### Which issue this PR fixes
This PR fixes the following issue: https://github.com/vmware-tanzu/velero/issues/2021
